### PR TITLE
Fixed `datetime` and `pubdate` attributes

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -958,7 +958,7 @@ For `del`, `ins`, `time`.
 -}
 datetime : String -> Attribute msg
 datetime value =
-  stringProperty "datetime" value
+  attribute "datetime" value
 
 
 {-| Indicates whether this date and time is the date of the nearest `article`
@@ -966,7 +966,7 @@ ancestor element. For `time`.
 -}
 pubdate : String -> Attribute msg
 pubdate value =
-  stringProperty "pubdate" value
+  attribute "pubdate" value
 
 
 


### PR DESCRIPTION
`Html.Attributes.datetime` and `Html.Attributes.pubdate` currently don't work because "datetime" and "pubdate" aren't valid JS properties. See:

```javascript
> d = document.createElement('time')
<time>​</time>​
> d.datetime
undefined
> d.pubdate
undefined
```

Elm example:

```elm
import Html exposing (div, time, text, br)
import Html.Attributes exposing (datetime, pubdate, attribute)

main =
  div
    []
    [ time
        [ datetime "this won't work"
        , pubdate "this won't work"
        ]
        [ text "this won't work" ]
    , br [] []
    , time
        [ attribute "datetime" "this will work"
        , attribute "pubdate" "this will work"
        ]
        [ text "this will work" ]
    ]
```

This PR just changes them from `stringProperty`s to `attribute`s.