### PR TITLE
Changed the form attribute to use the attribute function to fix issues with the property being readonly on some browsers.

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -743,7 +743,7 @@ for value =
 -}
 form : String -> Attribute msg
 form value =
-  stringProperty "form" value
+  attribute "form" value
 
 
 


### PR DESCRIPTION
The form property of an input element is readonly on certain browsers, notably Firefox. As such it cannot be set from the property and has to be set with setAttribute. I've changed the Elm form attribute to use the attribute function instead of stringProperty to reflect this. For more details, see [the discussion here](https://github.com/elm-lang/html/issues/31).