### PR TITLE
Fix draggable attribute to use attribute instead of property

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -287,7 +287,7 @@ dir value =
 {-| Defines whether the element can be dragged. -}
 draggable : String -> Attribute msg
 draggable value =
-  stringProperty "draggable" value
+  attribute "draggable" value
 
 
 {-| Indicates that the element accept the dropping of content on it. -}


### PR DESCRIPTION
The `draggable` HTML attribute behaves differently from the JavaScript property, which is causing a bug where even passing `"false"` to `Html.Attributes.draggable` will still make the element draggable. Any truthy value being assigned to the JavaScript draggable property (including the string `"false"`) will result in the element being draggable.

<img width="519" alt="screen shot 2016-06-13 at 10 28 05 pm" src="https://cloud.githubusercontent.com/assets/2107646/16030402/355932e2-31b6-11e6-80a4-1265d54acea7.png">

Assigning by attribute allows the draggable attribute to correctly be set to `"true"` or `"false"`.

SSCCE:

```elm
import Html exposing (div, text)
import Html.Attributes exposing (draggable)

main =
  div [ draggable "false" ] [ text "hello" ]
```

<img width="549" alt="screen shot 2016-06-13 at 10 36 08 pm" src="https://cloud.githubusercontent.com/assets/2107646/16030506/45562bb8-31b7-11e6-9043-bbc5ecc0881e.png">

vs.

```elm
import Html exposing (div, text)
import Html.Attributes exposing (attribute)

main =
  div [ attribute "draggable" "false" ] [ text "hello" ]
```

<img width="548" alt="screen shot 2016-06-13 at 10 37 37 pm" src="https://cloud.githubusercontent.com/assets/2107646/16030532/7a34c1aa-31b7-11e6-95bf-e54d7f5f2684.png">
