### PR TITLE
#40 Fix the `Html.Attributes.list` function

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -646,7 +646,7 @@ For `input`.
 -}
 list : String -> Attribute msg
 list value =
-  stringProperty "list" value
+  attribute "list" value
 
 
 {-| Defines the minimum number of characters allowed in an `input` or


### PR DESCRIPTION
See #40 for reference. It was using the `list` property of the `InputElement`, where this property doesn't exist.