### PR TITLE
Make draggable attribute take a Bool

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -285,9 +285,9 @@ dir value =
 
 
 {-| Defines whether the element can be dragged. -}
-draggable : String -> Attribute msg
+draggable : Bool -> Attribute msg
 draggable value =
-  attribute "draggable" value
+  attribute "draggable" <| if value then "true" else "false"
 
 
 {-| Indicates that the element accept the dropping of content on it. -}


### PR DESCRIPTION
Even though the `draggable` attribute is enumerated, it has only 2 valid values that can be assigned to it: `"true"` and `"false"`.

Given that, I think it would be a nicer interface to expose this as taking a `Bool` rather than any arbitrary `String`.