### PR TITLE
Clarify `Html.Attributes.classList` example code snippet

### DIFF
--- a/src/Html/Attributes.elm
+++ b/src/Html/Attributes.elm
@@ -127,17 +127,17 @@ style =
 Each class can easily be added and removed depending on the boolean value it
 is paired with.
 
-    renderMessage : Msg -> Html
-    renderMessage msg =
+    renderNotice : Notice -> Html msg
+    renderNotice notice =
       div
         [
           classList [
             ("message", True),
-            ("message-important", msg.isImportant),
-            ("message-read", msg.isRead)
+            ("message-important", notice.isImportant),
+            ("message-read", notice.isRead)
           ]
         ]
-        [ text msg.content ]
+        [ text notice.content ]
 -}
 classList : List (String, Bool) -> Attribute msg
 classList list =


### PR DESCRIPTION
* Example `renderMessage` function should return an `Html msg`
* Changed `renderMessage` function name and type signature to remove ambiguity with standard usage of `Msg` type

Passing a `Msg` type as an argument to the `renderMessage` function in the example code and calling `msg.isImport`, etc. could be rather confusing to a beginner. Being familiar with Elm types, type aliases, and the Cmd/Msg paradigm myself, I did a double take before realizing the `msg` parameter was simply a confusingly named record (assuming carried over from pre-Cmd/Msg days). Removed the message concept from the example to avoid ambiguity.