### PR TITLE
Highlight use of reference equality in Lazy doc

### DIFF
--- a/src/Html/Lazy.elm
+++ b/src/Html/Lazy.elm
@@ -8,8 +8,8 @@ about building `Html` that utilize this fact.
 
 Rather than immediately applying functions to their arguments, the `lazy`
 functions just bundle the function and arguments up for later. When diffing
-the old and new virtual DOM, it checks to see if all the arguments are equal.
-If so, it skips calling the function!
+the old and new virtual DOM, it checks to see if all the arguments are equal
+by reference. If so, it skips calling the function!
 
 This is a really cheap test and often makes things a lot faster, but definitely
 benchmark to be sure!


### PR DESCRIPTION
I know it says so in the doc comment for `lazy` but I think it would be helpful to highlight it a little more. People might just read the opening docs, see that it just says "equal" and not "equal by reference" and assume it means Elm's equality semantics without reading on to the doc comment for `lazy`.