### PR TITLE
Add Html.none

### DIFF
--- a/src/Html.elm
+++ b/src/Html.elm
@@ -137,6 +137,23 @@ text =
 
 
 
+-- CONDITIONAL RENDERING
+
+{-| Useful for rendering nothing when you have something you want to render
+conditionally. This is equivalent to using `Html.text ""`
+
+    view : Bool -> Html Msg
+    view bool =
+      if bool then
+        Html.div [] [ Html.text "It's True!" ]
+      else
+        Html.none
+
+-}
+none : Html msg
+none = VirtualDom.text ""
+
+
 -- NESTING VIEWS
 
 


### PR DESCRIPTION
I've added a "neutral-element" for DOM-nodes - I think it would help communicate more clearly when you wish to conditionally render something, instead of using `Html.text ""` directly.

I'm adding it simply becase it was the first thing I tried to use when I wanted to have something conditionally rendered in my application. This is in the spirit of `Cmd.none`and `Sub.none`.

Let me know what you think