### PR TITLE
Update example to use toString instead of String.fromInt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ view : Int -> Html Msg
 view count =
   div []
     [ button [ onClick Decrement ] [ text "-" ]
-    , div [] [ text (String.fromInt count) ]
+    , div [] [ text (toString count) ]
     , button [ onClick Increment ] [ text "+" ]
     ]
 ```


### PR DESCRIPTION
Use `toString` from Basics instead of the (removed) `String.fromInt` function to convert to String in the example.